### PR TITLE
TST / DEBUG: better warnings and tests when facing singular hessian problems

### DIFF
--- a/sklearn/linear_model/_glm/tests/test_glm.py
+++ b/sklearn/linear_model/_glm/tests/test_glm.py
@@ -810,7 +810,7 @@ def test_linalg_warning_with_newton_solver(global_random_seed):
     )
     with pytest.warns(scipy.linalg.LinAlgWarning, match=msg) as rec:
         reg = PoissonRegressor(solver="newton-cholesky", alpha=0.0).fit(X_colinear, y)
-    # XXX: this cases raises a ton of convergence warnings:
+    # XXX: this case raises a ton of convergence warnings:
     # - for each iteration:
     #   - one LinAlgWarning for the singular hessian
     #   - one ConvergenceWarning for the subsequent line search

--- a/sklearn/linear_model/_glm/tests/test_glm.py
+++ b/sklearn/linear_model/_glm/tests/test_glm.py
@@ -798,7 +798,7 @@ def test_linalg_warning_with_newton_solver(global_random_seed):
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         reg = PoissonRegressor(solver="newton-cholesky", alpha=0.0).fit(X_orig, y)
-        reference_deviance = mean_poisson_deviance(y, reg.predict(X_orig))
+    reference_deviance = mean_poisson_deviance(y, reg.predict(X_orig))
 
     # Fitting on collinear data without regularization should raise an
     # informative warning:


### PR DESCRIPTION
Here is an attempt (failed or successful depending on the viewpoint) at improving the tests for the fallback inner solver for the singular Hessian case in the context of the `"newton-cholesky"` solver introduced in https://github.com/scikit-learn/scikit-learn/pull/23314.

I think in it's current state, it's pretty useless:

- either with `lstsq` or `indefinite_factorization`, the model never converges, all line searches fail, the deviance stays very high and we issue a ton of useless warnings.
- `lstsq` seems to be a bit faster but it's not important since neither method is helpful at making the model converge.

Possible things to try:

- a) do not try to do a linear search on a singular hessian solution and instead continue warning but instead do a simple gradient step with small learning rate. But then we are not sure how small a learning rate. Or maybe we could try to run the line search with the raw gradient direction?
- b) when facing a singular hessian, just stop the solver with a helpful convergence warning that suggests less collinear features or stronger regularization
- c) alternatively, we could warn and try to fit the linear model again with strong regularization automatically (without ever trying to find a solution for the first encountered singular hessian problem)

Note that the suggestion to slightly increase the regularization works as shown in the last section of the test.